### PR TITLE
Add CI/CD builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build release zips
+
+on:
+  pull_request:
+    branches: [ "master" ]  
+  push:
+    branches: [ "master" ]
+    tags:
+      - '*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        configuration: [ "Debug", "Release" ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+      - name: Pull Cached NuGet Restore Data
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: "Build configuration: ${{ matrix.configuration }}"
+        run: dotnet build -c ${{ matrix.configuration }} --no-restore --nologo
+      - name: "Publish configuration: ${{ matrix.configuration }}"
+        run: dotnet publish -c ${{ matrix.configuration }} --no-build --nologo -o publish_output
+      - name: "Zip binaries for configuration: ${{ matrix.configuration }}"
+        run: pushd publish_output && zip ../EasyCards-${{ matrix.configuration }}-${{github.run_number}}.zip -r ./; popd
+      - name: Upload EasyCards-${{ matrix.configuration }}-${{github.run_number}}.zip
+        uses: actions/upload-artifact@v3
+        with:
+          path: EasyCards-${{ matrix.configuration }}-${{github.run_number}}.zip
+        
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Upload EasyCards-${{ matrix.configuration }}-${{github.run_number}}.zip
         uses: actions/upload-artifact@v3
         with:
+          name: EasyCards-${{ matrix.configuration }}-${{github.run_number}}.zip
           path: EasyCards-${{ matrix.configuration }}-${{github.run_number}}.zip
         
         

--- a/.github/workflows/pr-artifact-comment.yml
+++ b/.github/workflows/pr-artifact-comment.yml
@@ -1,0 +1,21 @@
+name: add artifact links to pull request and related issues
+on:
+  workflow_run:
+    workflows: 
+      - "Build release zips"
+    types:
+      - completed
+
+jobs:
+  artifacts-url-comments:
+    name: add artifact links to pull request and related issues job
+    runs-on: ubuntu-latest
+    steps:
+      - name: add artifact links to pull request and related issues step
+        uses: tonyhallett/artifacts-url-comments@v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          prefix: "### Artifacts"
+          format: name
+          addTo: pull

--- a/.github/workflows/pr-artifact-comment.yml
+++ b/.github/workflows/pr-artifact-comment.yml
@@ -1,4 +1,4 @@
-name: add artifact links to pull request and related issues
+name: pr-artifact-comment
 on:
   workflow_run:
     workflows: 

--- a/EasyCards/EasyCards.csproj
+++ b/EasyCards/EasyCards.csproj
@@ -60,8 +60,7 @@
 
   <ItemGroup>
     <!-- Content to copy -->
-    <Content Include="../DataToCopy/**/*" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" LinkBase="DataToCopy" />
-    <Content Include="../Documentation/**/*" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" LinkBase="Documentation" />
+    <Content Include="../DataToCopy/EasyCards/**/*" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" LinkBase="EasyCards" />
   </ItemGroup>
   <ItemGroup>
     <!-- the compiler will copy these, since they're referenced -->
@@ -74,7 +73,11 @@
       <FilesToDelete Include="$(PublishDir)*.pdb" />
       <FilesToDelete Include="$(PublishDir)*.deps.json" />
     </ItemGroup>
-    <Message Text="Deleting Files @(FilesToDelete) from publish output" Importance="high" />
+    <Message Text="Deleting references and debug symbols from publish output" Importance="high" />
     <Delete Files="@(FilesToDelete)" />
+  </Target>
+  <Target Name="CreateDataDirectory" AfterTargets="Publish">
+    <Message Text="Creating EasyCards/Data directory" Importance="high" />
+    <MakeDir Directories="$(PublishDir)EasyCards/Data" ContinueOnError="true" />
   </Target>
 </Project>

--- a/EasyCards/EasyCards.csproj
+++ b/EasyCards/EasyCards.csproj
@@ -67,4 +67,14 @@
     <!-- the compiler will copy these, since they're referenced -->
     <None Include="../Libraries/**/*" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" LinkBase="Libraries" />
   </ItemGroup>
+  
+  <Target Name="PostPublishCleanup" AfterTargets="Publish" Condition="'$(Configuration)' == 'Release'">
+    <ItemGroup>
+      <FilesToDelete Include="$(PublishDir)*.dll" Exclude="$(PublishDir)$(TargetName).dll" />
+      <FilesToDelete Include="$(PublishDir)*.pdb" />
+      <FilesToDelete Include="$(PublishDir)*.deps.json" />
+    </ItemGroup>
+    <Message Text="Deleting Files @(FilesToDelete) from publish output" Importance="high" />
+    <Delete Files="@(FilesToDelete)" />
+  </Target>
 </Project>


### PR DESCRIPTION
This updates the project file to produce output files in the same format that has been published on discord.
Then added a github actions CI/CD script to build both release and debug configurations, zip them, and upload them as artifacts.

In the future, we can use a github action to publish releases when they're tagged as well. But this is the foundation for that.