### PR TITLE
Fix banishing cards

### DIFF
--- a/EasyCards/Bootstrap/CardLoader.cs
+++ b/EasyCards/Bootstrap/CardLoader.cs
@@ -210,7 +210,7 @@ public sealed class CardLoader : ICardLoader
                 Logger.LogDebug($"\t\t{banishedCard.name}");
             }
 
-            cardScso.CardExclusion = finalList.ToIl2CppReferenceArray();
+            cardScso.Exclusions = finalList.ToIl2CppReferenceArray();
         }
     }
 

--- a/EasyCards/EasyCards.csproj
+++ b/EasyCards/EasyCards.csproj
@@ -4,10 +4,10 @@
         <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>EasyCards</AssemblyName>
         <Description></Description>
-        <Version>1.0.7</Version>
+        <Version>1.0.8</Version>
         <LangVersion>latest</LangVersion>
         <RootNamespace>EasyCards</RootNamespace>
-        <PackageVersion>1.0.7</PackageVersion>
+        <PackageVersion>1.0.8</PackageVersion>
         <Nullable>enable</Nullable>
         <Authors>chendrak</Authors>
     </PropertyGroup>


### PR DESCRIPTION
We were using `CardExclusion` vs `Exclusions`. Seems to have changed at some point without us knowing